### PR TITLE
feat: 공통 컴포넌트 뱃지 구현

### DIFF
--- a/src/app/test/badge/page.tsx
+++ b/src/app/test/badge/page.tsx
@@ -1,0 +1,35 @@
+import Badge from '../../../components/common/badge/Badge'
+
+const mockTags = ['Action', 'RPG', 'Multiplayer', 'Indie', 'Fantasy']
+
+export default function BadgeTestPage() {
+  return (
+    <main className="min-h-screen bg-neutral-900 p-10 text-white">
+      <h1 className="mb-6 text-2xl font-bold">Badge / Tag UI Test</h1>
+
+      <section className="space-y-4">
+        <h2 className="text-lg font-semibold">Game Tags</h2>
+
+        <div className="flex flex-wrap gap-2">
+          {mockTags.map((tag) => (
+            <Badge key={tag} variant="lightcyan">
+              #{tag}
+            </Badge>
+          ))}
+        </div>
+      </section>
+
+      <section className="mt-8 space-y-4">
+        <h2 className="text-lg font-semibold">Variant Preview</h2>
+
+        <div className="flex flex-wrap gap-2">
+          <Badge variant="lightcyan">#Action</Badge>
+          <Badge variant="purple">#RPGRPGRPGRPGRPG</Badge>
+          <Badge variant="cyan">#Indie</Badge>
+          <Badge variant="lightpurple">#Casual</Badge>
+          <Badge variant="darksky">#RPGRPGRPGRPGRPG</Badge>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/src/components/common/badge/Badge.tsx
+++ b/src/components/common/badge/Badge.tsx
@@ -1,0 +1,25 @@
+import type { VariantProps } from 'class-variance-authority'
+import { cn } from '../../../utils/cn'
+import { badgeVariants } from './badgeStyle'
+
+export type BadgeProps = React.ComponentPropsWithoutRef<'span'> &
+  VariantProps<typeof badgeVariants> & {
+    children: React.ReactNode
+  }
+/**
+ * 상태 컴포넌트
+ * @param variant - 뱃지 스타일
+ * @param children - 뱃지 내용
+ */
+export default function Badge({
+  className,
+  variant,
+  children,
+  ...rest
+}: BadgeProps) {
+  return (
+    <span className={cn(badgeVariants({ variant }), className)} {...rest}>
+      {children}
+    </span>
+  )
+}

--- a/src/components/common/badge/badgeStyle.tsx
+++ b/src/components/common/badge/badgeStyle.tsx
@@ -1,0 +1,19 @@
+import { cva } from 'class-variance-authority'
+
+export const badgeVariants = cva(
+  'inline-flex items-center justify-center rounded-[var(--radius-default)] px-3 py-1 text-sm font-medium whitespace-nowrap text-[var(--color-text-dark)] font-family: var(--font-family-base)',
+  {
+    variants: {
+      variant: {
+        lightcyan: 'bg-[#2fbdee]',
+        cyan: 'bg-[#22D3EE]',
+        purple: 'bg-[#9f57f6]',
+        darksky: 'bg-[#5086F0]',
+        lightpurple: 'bg-[#6966F2]',
+      },
+    },
+    defaultVariants: {
+      variant: 'lightcyan',
+    },
+  }
+)


### PR DESCRIPTION
## 📌 작업 내용

- 공통으로 사용할 뱃지 구현
- badge 테스트페이지 구현

## 🔗 관련 이슈

- closes #35 

## 📸 스크린샷 (선택)
<img width="956" height="318" alt="스크린샷 2026-01-09 오후 10 52 56" src="https://github.com/user-attachments/assets/538a2365-a84b-4ff1-b3a4-59c627728d88" />

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
