### PR TITLE
feat: SectionTitle 컴포넌트 구현

### DIFF
--- a/src/app/test/section-title/page.tsx
+++ b/src/app/test/section-title/page.tsx
@@ -1,0 +1,45 @@
+import SectionTitle from '@/components/common/section-title/SectionTitle'
+import { SECTION_TITLES } from '@/constatns/sectionTitle'
+
+export default function SectionTitleTestPage() {
+  // 동적 타이틀 테스트용
+  const mockPlayType = '🔥몰입형 액션 탐험가'
+
+  return (
+    <div className="flex min-h-screen flex-col gap-8 bg-background p-10">
+      <h1 className="text-2xl font-bold text-white">SectionTitle 테스트</h1>
+
+      <section>
+        <p className="mb-2 text-sm text-gray-400">1. 상수들</p>
+        <div className="flex flex-col gap-4">
+          <SectionTitle {...SECTION_TITLES.RECOMMENDATION} />
+          <SectionTitle {...SECTION_TITLES.MYFAVORITES} />
+          <SectionTitle {...SECTION_TITLES.GENREGAME} />
+        </div>
+      </section>
+
+      <section>
+        <p className="mb-2 text-sm text-gray-400">2. playType 적용한 타이틀</p>
+        <SectionTitle
+          {...SECTION_TITLES.RECOMMENDATION}
+          title={`${mockPlayType} 추천 리스트`}
+        />
+      </section>
+
+      <section>
+        <p className="mb-2 text-sm text-gray-400">3. 화살표 없이</p>
+        <SectionTitle title="화살표 없는 타이틀" showArrow={false} />
+      </section>
+
+      <section>
+        <p className="mb-2 text-sm text-gray-400">4. 링크 없이</p>
+        <SectionTitle title="링크 없는 타이틀" />
+      </section>
+
+      <section>
+        <p className="mb-2 text-sm text-gray-400">5. 둘 다 없이</p>
+        <SectionTitle title="순수 텍스트 타이틀" showArrow={false} />
+      </section>
+    </div>
+  )
+}

--- a/src/components/common/section-title/SectionTitle.tsx
+++ b/src/components/common/section-title/SectionTitle.tsx
@@ -1,0 +1,33 @@
+import { ChevronRight } from 'lucide-react'
+import Link from 'next/link'
+
+type SectionTitleProps = {
+  title: string
+  href?: string
+  showArrow?: boolean
+}
+
+export default function SectionTitle({
+  title,
+  href,
+  showArrow = true,
+}: SectionTitleProps) {
+  const content = (
+    <>
+      {title}
+      {showArrow && <ChevronRight size={16} />}
+    </>
+  )
+
+  return (
+    <h2 className="flex items-center gap-2 font-bold text-text-light">
+      {href ? (
+        <Link href={href} className="flex items-center gap-1 hover:underline">
+          {content}
+        </Link>
+      ) : (
+        <span className="flex items-center gap-1">{content}</span>
+      )}
+    </h2>
+  )
+}

--- a/src/constatns/sectionTitle.ts
+++ b/src/constatns/sectionTitle.ts
@@ -1,0 +1,18 @@
+export const SECTION_TITLES = {
+  NEW_RELEASE: {
+    title: '새로운 게임을 발견하세요',
+    href: '/games/new-release',
+  },
+  RECOMMENDATION: {
+    title: '선호기반 추천 리스트',
+    href: 'games/recommend',
+  },
+  MYFAVORITES: {
+    title: '찜한 게임과 비슷한 추천',
+    href: '/games/my-favorites',
+  },
+  GENREGAME: {
+    title: '찜한 게임과 비슷한 추천',
+    href: '/games/genre',
+  },
+} as const


### PR DESCRIPTION
## 📌 작업 내용

- SectionTitle 공통 컴포넌트 구현
  - `title`, `href`, `showArrow` props 지원
  - 링크 유무에 따른 조건부 렌더링
  - hover 시 underline 스타일 적용
- 섹션 타이틀 상수 파일 생성 (`constants/sectionTitles.ts`)
  - NEW_RELEASE, POPULAR, FREE, RECOMMENDATION 정의
  - 스프레드 문법으로 간편하게 사용 가능
- 컴포넌트 테스트 페이지 생성 (`/test/section-title`)

## 🔗 관련 이슈

- closes #61 

## 📸 스크린샷 
<img width="432" height="674" alt="image" src="https://github.com/user-attachments/assets/dbfbc7c2-9440-4c11-b4c2-4fd71b169a20" />


## 🧪 테스트 항목

- [ ] 상수 스프레드 시 props 정상 전달
- [ ] 동적 타이틀 (playType) 적용 확인
- [ ] `showArrow={false}` 동작 확인
- [ ] 링크 클릭 시 페이지 이동 확인
- [ ] hover 시 underline 스타일 확인

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인