### PR TITLE
feat: 인증 시스템 구축 및 스토어에 userinfo 정보 저장

### DIFF
--- a/src/api/fetchers/authFetchers.ts
+++ b/src/api/fetchers/authFetchers.ts
@@ -19,3 +19,15 @@ export const loginApi = async (data: LoginRequest) => {
 
   return res.data
 }
+
+/**
+ * TODO: 리프래쉬 api 추가 될 예정
+ * LOGIN_REFRESH_API_PATH 값 변경 예정
+ */
+export const refreshApi = async () => {
+  const res = await api.post(
+    `${API_BASE_URL}${API_PATH.LOGIN_REFRESH_API_PATH}`
+  )
+
+  return res.data
+}

--- a/src/api/fetchers/userInfoFetchers.ts
+++ b/src/api/fetchers/userInfoFetchers.ts
@@ -1,0 +1,17 @@
+import { API_BASE_URL, API_PATH } from '@/constants/apiPath'
+import api from '@/utils/axios'
+
+export type UserInfo = {
+  id: number
+  email: string
+  nickname: string
+  name: string
+  gender: string
+  isActive: true
+}
+
+export const getUserInfoApi = async (): Promise<UserInfo> => {
+  const res = await api.get(`${API_BASE_URL}${API_PATH.USER_INFO_GET_API_PATH}`)
+
+  return res.data
+}

--- a/src/components/feature/auth/login/LoginForm.tsx
+++ b/src/components/feature/auth/login/LoginForm.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 
 import { loginApi } from '@/api/fetchers/authFetchers'
+import { getUserInfoApi } from '@/api/fetchers/userInfoFetchers'
 import { compoundLogoColumn } from '@/assets'
 import { BaseInput, Button, LoginFormValues, loginSchema } from '@/components'
 import { ROUTES_PATHS } from '@/constants'
@@ -15,24 +16,14 @@ import { useAuthStore } from '@/store/useAuthStore'
  * 로그인 폼 컴포넌트
  */
 export default function LoginForm() {
+  const router = useRouter()
+  const { triggerToast } = useToast()
+  const { setToken, setUser } = useAuthStore()
   const [form, setForm] = useState<LoginFormValues>({
     id: '',
     password: '',
   })
-  const router = useRouter()
-  const { triggerToast } = useToast()
-  const { setToken } = useAuthStore()
-  /**
-   * TODO: 이메일/비밀번호 상태 관리 (useState)
-   * TODO: 입력값 유효성 검사
-   * TODO: 로그인 API 연결
-   * TODO: 에러 메시지 처리
-   * TODO: 로그인 성공 시 토큰 저장
-   * TODO: 로그인 후 페이지 이동 처리
-   */
-  /**
-   * 로그인 성공 시 토스트
-   */
+
   const handleSubmit = async () => {
     const { id, password } = form
     const result = loginSchema.safeParse({ id, password })
@@ -45,6 +36,10 @@ export default function LoginForm() {
     try {
       const data = await loginApi({ email: id, password })
       setToken(data.accessToken)
+
+      const userInfo = await getUserInfoApi()
+      setUser(userInfo)
+
       triggerToast('success', '로그인 성공')
       router.replace(ROUTES_PATHS.MAIN_PAGE)
     } catch {

--- a/src/components/providers/AuthProvider.tsx
+++ b/src/components/providers/AuthProvider.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { useEffect } from 'react'
+
+import { refreshApi } from '@/api/fetchers/authFetchers'
+import { useAuthStore } from '@/store/useAuthStore'
+
+/**
+ * 리프래쉬 시도를 통해 로그인 상태로 복구하는 역할
+ */
+export default function AuthProvider({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const { setToken, clear, setInitialized } = useAuthStore()
+
+  useEffect(() => {
+    const initAuth = async () => {
+      try {
+        /**
+         * refresh 시도
+         */
+        const token = await refreshApi()
+        /**
+         * store 복구
+         */
+        setToken(token)
+      } catch {
+        clear()
+      } finally {
+        /**
+         * 3. 인증 초기화 완료 표시
+         */
+        setInitialized(true)
+      }
+    }
+
+    initAuth()
+  }, [setToken, clear, setInitialized])
+
+  return children
+}

--- a/src/components/providers/Providers.tsx
+++ b/src/components/providers/Providers.tsx
@@ -5,6 +5,7 @@ import { ReactNode, useEffect, useState } from 'react'
 import TanstackQueryProvider from '@/components/providers/TanstackQueryProvider'
 import { ToastProvider } from '@/components/providers/ToastProvider'
 
+import AuthProvider from './AuthProvider'
 interface ProvidersProps {
   children: ReactNode
 }
@@ -28,7 +29,9 @@ export default function Providers({ children }: ProvidersProps) {
 
   return (
     <TanstackQueryProvider>
-      <ToastProvider>{children}</ToastProvider>
+      <AuthProvider>
+        <ToastProvider>{children}</ToastProvider>
+      </AuthProvider>
     </TanstackQueryProvider>
   )
 }

--- a/src/constants/apiPath.ts
+++ b/src/constants/apiPath.ts
@@ -9,9 +9,10 @@ export const API_PATH = {
     `/community/reviews/${review_id}/comments`,
   GAMES: '/games',
   GAME_DETAIL: (gameId: number) => `/games/${gameId}`,
-  LOGIN_API_PATH: '/user/login/',
+  LOGIN_API_PATH: '/user/login',
   /**
    * TODO: 리프레쉬 refresh api 추가 예정
    */
   LOGIN_REFRESH_API_PATH: '/',
+  USER_INFO_GET_API_PATH: '/user/me',
 } as const

--- a/src/hooks/useAuthGuard.ts
+++ b/src/hooks/useAuthGuard.ts
@@ -1,0 +1,27 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useEffect } from 'react'
+
+import { API_PATH } from '@/constants/apiPath'
+import { useAuthStore } from '@/store/useAuthStore'
+
+/**
+ * 인증 가드 훅
+ * 인증값이 없을 경우 로그인페이지로 강제 이동
+ * TODO: API 연결 후 필요한 페이지에 기입 ex) 마이페이지
+ */
+export default function useAuthGuard() {
+  const router = useRouter()
+  const { accessToken, isInitialized } = useAuthStore()
+
+  useEffect(() => {
+    if (!isInitialized) {
+      return
+    }
+
+    if (!accessToken) {
+      router.replace(API_PATH.LOGIN_API_PATH)
+    }
+  }, [accessToken, isInitialized, router])
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+/**
+ * 미들웨어 서버 가드
+ * 사용자가 직접 url을 치고 접속하지 못하게 하기 위해 생성
+ */
+export function middleware(req: NextRequest) {
+  const refreshToken = req.cookies.get('refreshToken')
+
+  if (!refreshToken) {
+    const loginUrl = new URL('/login', req.url)
+    return NextResponse.redirect(loginUrl)
+  }
+
+  return NextResponse.next()
+}
+
+/**
+ * 적용 경로 제한
+ */
+export const config = {
+  matcher: ['/mypage/:path*', '/community/reviews/:path*', '/user/me'],
+}

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -1,13 +1,42 @@
 import { create } from 'zustand'
 
+import { UserInfo } from '@/api/fetchers/userInfoFetchers'
+
 type AuthState = {
   accessToken: string | null
-  setToken: (t: string) => void
+  user: UserInfo | null
+  isInitialized: boolean
+
+  setToken: (token: string | null) => void
+  setUser: (user: UserInfo | null) => void
   clear: () => void
+  setInitialized: (v: boolean) => void
 }
 
 export const useAuthStore = create<AuthState>((set) => ({
   accessToken: null,
-  setToken: (token) => set({ accessToken: token }),
-  clear: () => set({ accessToken: null }),
+  user: null,
+  isInitialized: false,
+
+  setToken: (token) =>
+    set({
+      accessToken: token,
+    }),
+
+  setUser: (user) =>
+    set({
+      user,
+    }),
+
+  clear: () =>
+    set({
+      accessToken: null,
+      user: null,
+      isInitialized: true,
+    }),
+
+  setInitialized: (value) =>
+    set({
+      isInitialized: value,
+    }),
 }))

--- a/src/utils/axios.ts
+++ b/src/utils/axios.ts
@@ -69,7 +69,8 @@ const attachDefaultResponseInterceptor = (instance: AxiosInstance) => {
 
         return api(original)
       } catch (e) {
-        useAuthStore.getState().clear()
+        const store = useAuthStore.getState()
+        store.clear()
         location.href = ROUTES_PATHS.LOGIN_PAGE
         return Promise.reject(e)
       }


### PR DESCRIPTION
## 📌 작업 내용

- 로그인 여부 사용 방법 ex)
```
const { user, accessToken, isInitialized } = useAuthStore()
...
...
...
if (!isInitialized) return null

return user ? <UserMenu /> : <LoginButton />
return accessToken ? <UserMenu /> : <LoginButton />
```

- Axios interceptor에 refresh 토큰 처리 추가
- accessToken 자동 재발급 로직 구현
- AuthProvider 추가 (앱 시작 시 인증 복구)
- Zustand auth store 설계 (token, user, init)
- Providers에 AuthProvider 연결
- useAuthGuard 훅 추가 (페이지 보호 -> 추후 보호해야 할 페이지에 훅 추가)
- middleware 서버 가드 추가 (URL 직접 접근 차단)
- 초기 로딩 시 로그인 상태 복구 처리

## 🔗 관련 이슈

- closes #199 

## ✅ 체크리스트

- [x] 코드 컨벤션 확인
- [x] lint 에러 없음
- [x] 빌드 정상 확인
