### PR TITLE
chore: https 세팅

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "packageManager": "pnpm@9.0.0",
   "scripts": {
-    "dev": "next dev",
+    "dev": "node server.js",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,42 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+const fs = require('fs')
+const http = require('http')
+const https = require('https')
+
+const next = require('next')
+
+const dev = process.env.NODE_ENV !== 'production'
+const app = next({ dev })
+const handle = app.getRequestHandler()
+
+const PORT = 3000
+
+const KEY_PATH = './localhost-key.pem'
+const CERT_PATH = './localhost.pem'
+
+const hasHttpsCert = fs.existsSync(KEY_PATH) && fs.existsSync(CERT_PATH)
+
+app.prepare().then(() => {
+  if (hasHttpsCert) {
+    const httpsOptions = {
+      key: fs.readFileSync(KEY_PATH),
+      cert: fs.readFileSync(CERT_PATH),
+    }
+
+    https
+      .createServer(httpsOptions, (req, res) => {
+        handle(req, res)
+      })
+      .listen(PORT, () => {
+        console.log(`> HTTPS server ready on https://localhost:${PORT}`)
+      })
+  } else {
+    http
+      .createServer((req, res) => {
+        handle(req, res)
+      })
+      .listen(PORT, () => {
+        console.log(`> HTTP server ready on http://localhost:${PORT}`)
+      })
+  }
+})


### PR DESCRIPTION
## 📌 작업 내용

- https 세팅

## https 개발환경 세팅 방법
1. mkcert 설치
  - 아래 링크 참고해서 설치하세요
  - https://mkcert.org/
  - mac을 사용하는 경우 homebrew를 사용하시면 더 편하게 설치 가능합니다
2. 아래 명령어로 인증서를 발급받으세요
```
mkcert -install
mkcert localhost
```
  - `localhost-key.pem`과 `localhost.pem` 파일이 생성되어야합니다.
3. 개발 서버 실행
  -  `pnpm run dev`로 실행하면 https로 개발 서버가 실행됩니다.
  - 만약에 안되면 사용하고 계신 브라우저에 `localhost.pem`을 등록하셔야합니다.

## 🔗 관련 이슈

- closes #224

## 📸 스크린샷 (선택)
<img width="854" height="918" alt="Screenshot 2026-02-05 at 2 27 56 PM" src="https://github.com/user-attachments/assets/4c338a49-308a-4ec8-9fe0-008fd9d3a1c9" />

## ✅ 체크리스트

- [x] 코드 컨벤션 확인
- [x] lint 에러 없음
- [x] 빌드 정상 확인
