### PR TITLE
fix: auth refresh 관련 intercepter 부분 수정

### DIFF
--- a/src/components/common/auth/AuthGuard.tsx
+++ b/src/components/common/auth/AuthGuard.tsx
@@ -8,11 +8,15 @@ import { useAuthStore } from '@/store/useAuthStore'
 
 export default function AuthGuard({ children }: { children: React.ReactNode }) {
   const router = useRouter()
-
-  const { accessToken, isInitialized } = useAuthStore()
+  const accessToken = useAuthStore((s) => s.accessToken)
+  const isInitialized = useAuthStore((s) => s.isInitialized)
 
   useEffect(() => {
-    if (isInitialized && !accessToken) {
+    if (!isInitialized) {
+      return
+    }
+
+    if (!accessToken) {
       router.replace(ROUTES_PATHS.LOGIN_PAGE)
     }
   }, [isInitialized, accessToken, router])

--- a/src/components/common/auth/GuestGuard.tsx
+++ b/src/components/common/auth/GuestGuard.tsx
@@ -12,10 +12,15 @@ export default function GuestGuard({
   children: React.ReactNode
 }) {
   const router = useRouter()
-  const { accessToken, isInitialized } = useAuthStore()
+  const accessToken = useAuthStore((s) => s.accessToken)
+  const isInitialized = useAuthStore((s) => s.isInitialized)
 
   useEffect(() => {
-    if (isInitialized && accessToken) {
+    if (!isInitialized) {
+      return
+    }
+
+    if (accessToken) {
       router.replace(ROUTES_PATHS.MAIN_PAGE)
     }
   }, [isInitialized, accessToken, router])

--- a/src/components/providers/AuthProvider.tsx
+++ b/src/components/providers/AuthProvider.tsx
@@ -2,51 +2,23 @@
 
 import { useEffect } from 'react'
 
-import { refreshTokenApi } from '@/api/fetchers/authFetchers'
 import { useAuthStore } from '@/store/useAuthStore'
 
 /**
  * 리프래쉬 시도를 통해 로그인 상태로 복구하는 역할
+ * 역할: "초기화 완료"만 알려줌
+ * refresh는 interceptor에서만 처리
  */
 export default function AuthProvider({
   children,
 }: {
   children: React.ReactNode
 }) {
-  const { setToken, clear, setInitialized } = useAuthStore()
+  const setInitialized = useAuthStore((s) => s.setInitialized)
 
   useEffect(() => {
-    let mounted = true
-
-    const initAuth = async () => {
-      try {
-        const accessToken = await refreshTokenApi()
-
-        if (!mounted) {
-          return
-        }
-        setToken(accessToken)
-      } catch {
-        if (!mounted) {
-          return
-        }
-
-        clear()
-      } finally {
-        if (!mounted) {
-          return
-        }
-
-        setInitialized(true)
-      }
-    }
-
-    initAuth()
-
-    return () => {
-      mounted = false
-    }
-  }, [setToken, clear, setInitialized])
+    setInitialized(true)
+  }, [setInitialized])
 
   return children
 }


### PR DESCRIPTION
## 📌 작업 내용

- axios interceptor에서 access token 만료 시 refresh 흐름 개선
- refresh 요청을 단일화하여 동시 요청 시 중복 호출 방지
- refresh 성공 시 대기중인 요청을 재시도하도록 큐 처리 추가
- refresh 실패 또는 만료 시 로그아웃/리다이렉트 처리 보완
- 무한 재시도 루프 방지 로직 적용
- AuthProvider 및 Guard 컴포넌트에서 토큰 상태 동기화 및 에러 핸들링 보강
- MSW bypass 추가
- 관련 타입 정리 및 주석 추가

## 🔗 관련 이슈

- closes #232 

## ✅ 체크리스트

- [x] 코드 컨벤션 확인
- [x] lint 에러 없음
- [x] 빌드 정상 확인
