### PR TITLE
feat: 아이디_닉네임 중복 확인 버튼 api 연동

### DIFF
--- a/src/api/fetchers/authFetchers.ts
+++ b/src/api/fetchers/authFetchers.ts
@@ -93,3 +93,48 @@ export const deleteUserApi = async (data: DeleteUserRequest) => {
 export const logoutApi = async (): Promise<void> => {
   await api.post(`${API_BASE_URL}${API_PATH.USER_LOGOUT_API_PATH}`)
 }
+
+type CheckEmailRequest = {
+  email: string
+}
+
+type CheckEmailResponse = {
+  available: boolean
+  message: string
+}
+
+/**
+ * 이메일 중복 확인 API
+ */
+export const checkEmailApi = async (
+  data: CheckEmailRequest
+): Promise<CheckEmailResponse> => {
+  const res = await api.post<CheckEmailResponse>(
+    `${API_BASE_URL}${API_PATH.CHECK_EMAIL_API_PATH}`,
+    data
+  )
+  return res.data
+}
+
+type CheckNickNameRequest = {
+  nickname: string
+}
+
+type CheckNickNameResponse = {
+  available: boolean
+  message: string
+}
+
+/**
+ * 닉네임 중복 확인 API
+ */
+export const checkNickNameApi = async (
+  data: CheckNickNameRequest
+): Promise<CheckNickNameResponse> => {
+  const res = await api.post<CheckNickNameResponse>(
+    `${API_BASE_URL}${API_PATH.CHECK_NICKNAME_API_PATH}`,
+    data
+  )
+  console.log('res : ' + res)
+  return res.data
+}

--- a/src/components/feature/auth/SignupForm.tsx
+++ b/src/components/feature/auth/SignupForm.tsx
@@ -3,7 +3,12 @@
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 
-import { signupApi, type SignupRequest } from '@/api/fetchers/authFetchers'
+import {
+  checkEmailApi,
+  checkNickNameApi,
+  signupApi,
+  type SignupRequest,
+} from '@/api/fetchers/authFetchers'
 import {
   BaseInput,
   Button,
@@ -46,7 +51,7 @@ export default function SignupForm() {
   } as const
 
   const phoneTimer = usePhoneVerificationTimer({
-    duration: 10 /** TODO: 180초 */,
+    duration: 180,
     onExpire: () => triggerToast('error', '인증 시간이 만료되었습니다.'),
   })
 
@@ -108,20 +113,50 @@ export default function SignupForm() {
     }
   }
 
-  const handleIdCheckClick = () => {
-    /**
-     * TODO: 아이디 중복체크 이벤트 API 연동
-     * toast 진행 예정
-     */
-    setIsIdChecked(true)
+  const handleIdCheckClick = async () => {
+    if (!form.id) {
+      triggerToast('error', '아이디를 입력해 주세요.')
+    }
+
+    try {
+      const res = await checkEmailApi({
+        email: form.id,
+      })
+
+      if (res.available) {
+        triggerToast('success', res.message)
+        setIsIdChecked(true)
+      } else {
+        triggerToast('error', res.message)
+        setIsIdChecked(false)
+      }
+    } catch {
+      triggerToast('error', '이메일 중복 확인에 실패했습니다.')
+      setIsIdChecked(false)
+    }
   }
 
-  const handleNickNameCheckClick = () => {
-    /**
-     * TODO: 닉네임 중복체크 이벤트 API 연동
-     * toast 진행 예정
-     */
-    setIsNickNameChecked(true)
+  const handleNickNameCheckClick = async () => {
+    if (!form.nickName) {
+      triggerToast('error', '닉네임을 입력해 주세요.')
+    }
+
+    try {
+      const res = await checkNickNameApi({
+        nickname: form.nickName,
+      })
+
+      if (res.available) {
+        triggerToast('success', res.message)
+        setIsNickNameChecked(true)
+      } else {
+        triggerToast('error', res.message)
+        setIsNickNameChecked(false)
+      }
+    } catch {
+      triggerToast('error', '닉네임 중복 확인에 실패했습니다.')
+      setIsNickNameChecked(false)
+    }
   }
 
   return (

--- a/src/components/feature/mypage/user-info/user-update/UserInfoUpdateClient.tsx
+++ b/src/components/feature/mypage/user-info/user-update/UserInfoUpdateClient.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from 'next/navigation'
 import { useCallback, useState } from 'react'
 
+import { checkNickNameApi } from '@/api/fetchers/authFetchers'
 import { UserInfo } from '@/api/fetchers/userInfoFetchers'
 import { useGetUserMe } from '@/api/queries/useGetUserMe'
 import {
@@ -116,14 +117,27 @@ export default function UserInfoUpdateClient() {
     })
   }
 
-  const handleNickNameCheckClick = () => {
-    /**
-     * TODO: 닉네임 중복체크 이벤트 API 연동
-     * toast 진행 예정
-     */
-    setIsNickNameChecked(true)
+  const handleNickNameCheckClick = async () => {
+    if (!form.nickName) {
+      triggerToast('error', '닉네임을 입력해 주세요.')
+    }
 
-    alert('닉네임 중복체크')
+    try {
+      const res = await checkNickNameApi({
+        nickname: form.nickName,
+      })
+
+      if (res.available) {
+        triggerToast('success', res.message)
+        setIsNickNameChecked(true)
+      } else {
+        triggerToast('error', res.message)
+        setIsNickNameChecked(false)
+      }
+    } catch {
+      triggerToast('error', '닉네임 중복 확인에 실패했습니다.')
+      setIsNickNameChecked(false)
+    }
   }
 
   if (isLoading || !form || !baseUserInfo) {

--- a/src/constants/apiPath.ts
+++ b/src/constants/apiPath.ts
@@ -26,4 +26,6 @@ export const API_PATH = {
     `/game/wishlist/${wishlistId}`,
   GET_PROFILE_IMAGE_API_PATH: '/user/me/image',
   POST_PROFILE_IMAGE_API_PATH: '/user/me/image',
+  CHECK_EMAIL_API_PATH: '/user/check-email',
+  CHECK_NICKNAME_API_PATH: '/user/check-nickname',
 } as const


### PR DESCRIPTION
## 📌 작업 내용

- 아이디 및 닉네임 api 연동 구현
- 회원 가입 및 회원 정보 수정 폼 코드 수정

## 🔗 관련 이슈

- closes #240 

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
