### PR TITLE
feat: 검색 페이지 API 연동 및 검색어 태그 노출 로직 변경 

### DIFF
--- a/src/api/fetchers/searchFetchers.ts
+++ b/src/api/fetchers/searchFetchers.ts
@@ -1,0 +1,16 @@
+import { API_BASE_URL, API_PATH } from '@/constants/apiPath'
+import { GameList } from '@/types/api-response/game-response'
+import { camelApi } from '@/utils'
+
+export const getSearchParams = async (
+  q: string,
+  page = 1
+): Promise<GameList> => {
+  const res = await camelApi.get<GameList>(
+    `${API_BASE_URL}${API_PATH.GAMES_SEARCH}`,
+    {
+      params: { q, page },
+    }
+  )
+  return res.data
+}

--- a/src/api/queries/useSearchGame.ts
+++ b/src/api/queries/useSearchGame.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { QUERY_KEYS } from '@/constants/queryKey'
+
+import { getSearchParams } from '../fetchers/searchFetchers'
+
+export const useSearchGames = (q: string, page: number) => {
+  return useQuery({
+    queryKey: QUERY_KEYS.GAME_SEARCH_PARAM(q, page),
+    queryFn: () => getSearchParams(q, page),
+    enabled: !!q,
+    placeholderData: (previoseData) => previoseData,
+  })
+}

--- a/src/components/feature/search-page/SearchResults.tsx
+++ b/src/components/feature/search-page/SearchResults.tsx
@@ -2,35 +2,27 @@
 
 import { useSearchParams } from 'next/navigation'
 
+import { useSearchGames } from '@/api/queries/useSearchGame'
 import Badge from '@/components/common/badge/Badge'
 import GameCard from '@/components/common/game-card/GameCard'
 import { SearchEmptyUi } from '@/components/feature/search-page'
-import { MOCK_GAME } from '@/mocks/data/mockGameList'
-import { Game } from '@/types/api-response/game-response'
 import { getTagVariant } from '@/utils/getTagVariant'
 
 function SearchResults() {
   const searchParams = useSearchParams()
-  const query = searchParams.get('query')
-  const filters = searchParams.get('filters')
+  const query = searchParams.get('query') ?? ''
 
-  const filterList = filters ? filters.split(',').filter(Boolean) : []
+  const page = Number(searchParams.get('page') ?? 1)
 
-  const games = MOCK_GAME.filter((game: Game) => {
-    const matchesQuery =
-      !query || String(game.id).toLowerCase().includes(query.toLowerCase())
+  const { data, isLoading } = useSearchGames(query, page)
+  const games = data?.results ?? []
 
-    const matchesFilters =
-      filterList.length === 0 ||
-      filterList.some((filter) => {
-        const filterId = Number(filter)
-
-        return String(game.id).includes(String(filterId))
-        // || game.tagId?.includes(filterId)
-      })
-
-    return matchesQuery && matchesFilters
-  })
+  if (!query || !games.length) {
+    return <SearchEmptyUi />
+  }
+  if (isLoading) {
+    return <div>로딩중...</div>
+  }
 
   return (
     <main className="mx-auto my-14 max-w-345 px-4">
@@ -46,20 +38,17 @@ function SearchResults() {
           </div>
         )}
 
-        {filters && filterList.length > 0 && (
-          <div className="space-y-2">
-            <p className="text-sm text-text-secondary">적용된 필터</p>
-            <div className="flex flex-wrap gap-2">
-              {filterList.map((filter, index) => (
-                <Badge
-                  key={`${filter}-${index}`}
-                  variant={getTagVariant(index + 1)}
-                  size="md"
-                >
-                  {filter}
-                </Badge>
-              ))}
-            </div>
+        {query && (
+          <div className="flex flex-wrap gap-2">
+            {query.split(',').map((q, index) => (
+              <Badge
+                key={`search-${q}-${index}`}
+                variant={getTagVariant(index)}
+                size="md"
+              >
+                #{q}
+              </Badge>
+            ))}
           </div>
         )}
       </div>

--- a/src/constants/apiPath.ts
+++ b/src/constants/apiPath.ts
@@ -29,6 +29,7 @@ export const API_PATH = {
   MAIN_PAGE: '/',
   FIND_ID_API_PATH: '/user/find-account',
   USER_DELETE_API_PATH: '/user/me/delete',
+  GAMES_SEARCH: '/game/search',
 
   USER_PREFERENCE: '/user/preference/',
   USER_LOGOUT_API_PATH: '/user/logout',

--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -5,4 +5,6 @@ export const QUERY_KEYS = {
   GAME_RECOMMEND_WISHLIST: ['game', 'recommend', 'whishlist'] as const,
   GAME_LIST: (params: { page: number }) => ['game', 'list', params] as const,
   USER_PREFERENCE: ['preference'] as const,
+  GAME_SEARCH_PARAM: (q: string, page = 1) =>
+    ['games', 'search', q, page] as const,
 } as const


### PR DESCRIPTION

## 📌 변경 내용
- 검색 페이지에 실제 API 연동
- query, page 기반 검색 로직 구현
- 검색어 Badge 노출
- 결과 없음 / 로딩 상태 분기 처리

## 📎 참고
- API 요청은 200 OK 응답 확인 완료
- 현재 응답값 results: []로 반환되고 있어 실제 검색 데이터 확인 필요
- 검색 결과가 비어 있는 부분은 백엔드 측 로직 확인 예정

## 🔗 관련 이슈

- closes #271 

## 📸 스크린샷 

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
